### PR TITLE
Feat players controller

### DIFF
--- a/app/controllers/api/v1/players_controller.rb
+++ b/app/controllers/api/v1/players_controller.rb
@@ -27,7 +27,7 @@ class Api::V1::PlayersController < ApplicationController
     @game = Game.find(params[:game_id])
     return render json: { error: { message: "Game started. New players may not join." } }, status: :forbidden if @game.started?
   
-    if @game.players.count >= game.number_of_players
+    if @game.players.count >= @game.number_of_players
       render json: { error: { message: "Max players reached. New players may not join." } }, status: :forbidden
     end
   end

--- a/app/controllers/api/v1/players_controller.rb
+++ b/app/controllers/api/v1/players_controller.rb
@@ -1,8 +1,9 @@
 class Api::V1::PlayersController < ApplicationController
+  before_action :accepting_players?, only: :create
+
   def create
-    game = Game.find(params[:game_id])
-    player = game.players.create!(player_params)
-    render json: PlayerSerializer.new(player), status: :created
+      player = @game.players.create!(player_params)
+      render json: PlayerSerializer.new(player), status: :created
   end
 
   def show
@@ -22,6 +23,15 @@ class Api::V1::PlayersController < ApplicationController
   end
 
   private
+  def accepting_players?
+    @game = Game.find(params[:game_id])
+    return render json: { error: { message: "Game started. New players may not join." } }, status: :forbidden if @game.started?
+  
+    if @game.players.count >= game.number_of_players
+      render json: { error: { message: "Max players reached. New players may not join." } }, status: :forbidden
+    end
+  end
+  
   def player_params
     params.permit(:display_name, :answers_correct, :answers_incorrect)
   end

--- a/spec/factories/games.rb
+++ b/spec/factories/games.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     number_of_questions { Faker::Number.within(range: 1..10) }
     time_limit { Faker::Number.within(range: 5..120) }
     number_of_players { Faker::Number.within(range: 1..35) }
-    started { Faker::Boolean.boolean }
+    started { false }
     link { Faker::Internet.url }
   end
 end

--- a/spec/requests/api/v1/players_spec.rb
+++ b/spec/requests/api/v1/players_spec.rb
@@ -100,6 +100,32 @@ RSpec.describe 'Players API', type: :request do
           expect(error[:message]).to eq "Validation failed: Display name has already been taken"
         end
       end
+
+      response(403, 'Forbidden - game started') do
+        let(:game_id) { create(:game, started: true).id }
+        before { create(:player, display_name: 'trivia-ninja', game_id: game_id) }
+        let(:params) { {display_name: 'trivia-ninja'} }
+
+        run_test! do |example|
+          expect(response.status).to eq 403
+
+          error = JSON.parse(response.body, symbolize_names: true)[:error]
+          expect(error[:message]).to eq "Validation failed: Display name has already been taken"
+        end
+      end
+
+      response(403, 'Forbidden. New players may not join') do
+        let(:game_id) { create(:game).id }
+        before { create(:player, display_name: 'trivia-ninja', game_id: game_id) }
+        let(:params) { {display_name: 'trivia-ninja'} }
+
+        run_test! do |example|
+          expect(response.status).to eq 403
+
+          error = JSON.parse(response.body, symbolize_names: true)[:error]
+          expect(error[:message]).to eq "Validation failed: Display name has already been taken"
+        end
+      end
     end
   end
 

--- a/spec/requests/api/v1/players_spec.rb
+++ b/spec/requests/api/v1/players_spec.rb
@@ -101,29 +101,28 @@ RSpec.describe 'Players API', type: :request do
         end
       end
 
-      response(403, 'Forbidden - game started') do
+      response(403, 'Game has started') do
         let(:game_id) { create(:game, started: true).id }
-        before { create(:player, display_name: 'trivia-ninja', game_id: game_id) }
-        let(:params) { {display_name: 'trivia-ninja'} }
+        let(:params) { {display_name: 'here'} }
 
         run_test! do |example|
           expect(response.status).to eq 403
 
           error = JSON.parse(response.body, symbolize_names: true)[:error]
-          expect(error[:message]).to eq "Validation failed: Display name has already been taken"
+          expect(error[:message]).to eq "Game started. New players may not join."
         end
       end
 
-      response(403, 'Forbidden. New players may not join') do
-        let(:game_id) { create(:game).id }
-        before { create(:player, display_name: 'trivia-ninja', game_id: game_id) }
-        let(:params) { {display_name: 'trivia-ninja'} }
+      response(403, 'New players may not join game') do
+        let(:game_id) { create(:game, number_of_players: 1).id }
+        before { create(:player, display_name: 'player 1', game_id: game_id) }
+        let(:params) { {display_name: 'player 2'} }
 
         run_test! do |example|
           expect(response.status).to eq 403
 
           error = JSON.parse(response.body, symbolize_names: true)[:error]
-          expect(error[:message]).to eq "Validation failed: Display name has already been taken"
+          expect(error[:message]).to eq "Max players reached. New players may not join." 
         end
       end
     end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -118,8 +118,6 @@ paths:
                 display_name:
                   type: string
                   required: true
-                link:
-                  type: string
         required: true
   "/api/v1/games/{id}":
     parameters:
@@ -364,6 +362,8 @@ paths:
           description: Player's game not found
         '422':
           description: Display name taken
+        '403':
+          description: New players may not join game
       requestBody:
         content:
           application/json:


### PR DESCRIPTION
## Type of change
- [x] New feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Styling
- [ ] Documentation
- [ ] Other:

## Description

Players cannot join if a game already reached it's player count or if a game has already started.
Game factory set to have `started` attribute be false unless otherwise specified.

## Issue(s):
closes #39 

## Necessary checkmarks:
- [x] All Tests are Passing
- [x] The code will run locally
- [x] Unnecessary comments removed
- [x] Test coverage 100%

## Any Outstanding Issues/Problems?
- [x] My code is wonderful, no issues here!
- [ ] Yeah, see additional words below
