### PR TITLE
fix: update players

### DIFF
--- a/app/controllers/api/v1/players_controller.rb
+++ b/app/controllers/api/v1/players_controller.rb
@@ -18,12 +18,13 @@ class Api::V1::PlayersController < ApplicationController
   end
 
   def update
-    player = Player.find_by!(game_id: params[:game_id])
+    player = Player.find_by!(game_id: params[:game_id], id: params[:id])
     if params[:correct] == true
       player.update_correct_answers(params[:question])
     else
       player.update_incorrect_answers
     end
+    player.save!
     render json: PlayerSerializer.new(player)
   end
 

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -7,8 +7,9 @@ class Player < ApplicationRecord
   validates_presence_of :game_id
 
   def update_correct_answers(question)
-    self.questions_correct << question
-    self.answers_correct += 1
+    self.questions_correct << question.to_s
+    self.questions_correct.uniq!
+    self.answers_correct = self.questions_correct.size
   end
 
   def update_incorrect_answers

--- a/spec/models/player_spec.rb
+++ b/spec/models/player_spec.rb
@@ -20,31 +20,30 @@ RSpec.describe Player, type: :model do
 
   describe "instance methods" do
     before do
-      data = {
-        "id"=>8,
-        "topic"=>"Music Trivia",
-        "question_text"=>"What is the name of Rihanna's debut single?",
-        "correct_answer"=>"Pon de Replay",
-        "options"=>["Umbrella", "Diamonds", "Love on the Brain", "Pon de Replay"]
-      }
-
-      question_1 = Question.new(data)
-      question_2 = Question.new(data)
-
-      @game = Game.create!({topic: "Music Trivia", number_of_questions: 2, number_of_players: 1})
-
-      @player = Player.create!({display_name: "OP", game_id: @game.id})
+      game = create(:game)
+      @player = Player.create!({display_name: "OP", game_id: game.id})
     end
 
-    describe "#update_answers" do
+    describe "#update_correct_answers" do
       it "updates questions_correct array and answers_correct integer" do
         @player.update_correct_answers(1)
         @player.update_correct_answers(2)
 
-        expect(@player.questions_correct).to eq([1, 2])
+        expect(@player.questions_correct).to eq(["1", "2"])
         expect(@player.answers_correct).to eq(2)
       end
 
+      it "doesn't display duplicate question numbers in the questions array" do
+        expect(@player.questions_correct).to eq([])
+
+        @player.update_correct_answers(1)
+        @player.update_correct_answers(1)
+        expect(@player.questions_correct).to eq(["1"])
+        expect(@player.answers_correct).to eq(1)
+      end
+    end
+
+    describe "#update_incorrect_answers" do
       it "updates answers_incorrect integer" do
         @player.update_incorrect_answers
         @player.update_incorrect_answers

--- a/spec/requests/api/v1/players_spec.rb
+++ b/spec/requests/api/v1/players_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'Players API', type: :request do
                       answers_incorrect: { type: :integer, required: true },
                       questions_correct: { 
                         type: :array,
-                        items: { type: :integer }
+                        items: { type: :string }
                       }
                     }
                   }
@@ -93,7 +93,7 @@ RSpec.describe 'Players API', type: :request do
                     answers_incorrect: { type: :integer, required: true },
                     questions_correct: { 
                       type: :array,
-                      items: { type: :integer }
+                      items: { type: :string }
                     }
                   }
                 }
@@ -219,7 +219,7 @@ RSpec.describe 'Players API', type: :request do
                     answers_incorrect: { type: :integer, required: true },
                     questions_correct: { 
                       type: :array,
-                      items: { type: :integer }
+                      items: { type: :string }
                     }
                   }
                 }
@@ -296,7 +296,7 @@ RSpec.describe 'Players API', type: :request do
                     answers_incorrect: { type: :integer, required: true },
                     questions_correct: { 
                       type: :array,
-                      items: { type: :integer }
+                      items: { type: :string }
                     }
                   }
                 }
@@ -312,7 +312,7 @@ RSpec.describe 'Players API', type: :request do
           expect(parsed_data[:id].to_i).to eq id
           expect(parsed_data[:type]).to eq "player"
           expect(parsed_data[:attributes][:answers_correct]).to eq 1
-          expect(parsed_data[:attributes][:questions_correct]).to eq [1]
+          expect(parsed_data[:attributes][:questions_correct]).to eq ["1"]
         end
       end
 


### PR DESCRIPTION
prevent duplicates in questions_correct array
base answers_correct on question_correct array size update tests to reflect changes

## Type of change
- [ ] New feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Styling
- [ ] Documentation
- [ ] Other:

## Description

Players Controller
- search for player via game_id and id to ensure correct player record updated
- player updates are now saved

Player Model
- Add `.uniq` to prevent duplicate questions
- `answers_correct` based on` questions_correct` array size to prevent change if the same question number is sent twice for a player update
- question enters array as a string to allow for consistency in API response ( `["1", "2"]` instead of `["1", 2]` )

## Issue(s):
closes #44 

## Necessary checkmarks:
- [x] All Tests are Passing
- [x] The code will run locally
- [x] Unnecessary comments removed
- [x] Test coverage 100%

*What tests are still needed if coverage not 100%*

## Any Outstanding Issues/Problems?
- [x] My code is wonderful, no issues here!
- [ ] Yeah, see additional words below
