### PR TITLE
Fix/timeout

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ gem "rack-cors"
 
 # API Gems
 gem "faraday"
+gem "faraday-retry"
 gem "jsonapi-serializer"
 
 # rswag for api docs

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,6 +110,8 @@ GEM
       faraday-net_http (>= 2.0, < 3.2)
     faraday-net_http (3.1.0)
       net-http
+    faraday-retry (2.2.1)
+      faraday (~> 2.0)
     fugit (1.11.0)
       et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
@@ -302,6 +304,7 @@ DEPENDENCIES
   factory_bot_rails
   faker
   faraday
+  faraday-retry
   jsonapi-serializer
   pg (~> 1.1)
   pry

--- a/app/services/question_service.rb
+++ b/app/services/question_service.rb
@@ -5,7 +5,12 @@ class QuestionService
   end
 
   def self.post_url(url, params)
-    response = conn.post(url, params)
+    response = conn.post(url, params) do |req|
+      req.retry(max: 1, interval: 2) { |exception|
+      exception.is_a?(Faraday::TimeoutError)
+    }
+    end
+
     @parsed_json = JSON.parse(response.body, symbolize_names: true)
   end
 

--- a/app/services/question_service.rb
+++ b/app/services/question_service.rb
@@ -13,7 +13,7 @@ class QuestionService
 
   def self.conn
     Faraday.new(url: "https://brain-defrost-be-questions.onrender.com") do |faraday|
-      faraday.request :retry, max: 1, interval: 2, exceptions: [Faraday::TimeoutError]
+      faraday.request :retry, max: 2, interval: 2, exceptions: [Faraday::TimeoutError]
     end
   end
 end

--- a/app/services/question_service.rb
+++ b/app/services/question_service.rb
@@ -1,3 +1,5 @@
+require 'faraday/retry'
+
 class QuestionService
   def self.create_questions_for(game)
     post_url("/api/v1/questions", game)
@@ -5,16 +7,13 @@ class QuestionService
   end
 
   def self.post_url(url, params)
-    response = conn.post(url, params) do |req|
-      req.retry(max: 1, interval: 2) { |exception|
-      exception.is_a?(Faraday::TimeoutError)
-    }
-    end
-
+    response = conn.post(url, JSON.generate(params))
     @parsed_json = JSON.parse(response.body, symbolize_names: true)
   end
 
   def self.conn
-    Faraday.new(url: "https://brain-defrost-be-questions.onrender.com")
+    Faraday.new(url: "https://brain-defrost-be-questions.onrender.com") do |faraday|
+      faraday.request :retry, max: 1, interval: 2, exceptions: [Faraday::TimeoutError]
+    end
   end
 end


### PR DESCRIPTION
## Type of change
- [ ] New feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Styling
- [ ] Documentation
- [ ] Other:

## Description

If the API request to the questions microservice fails due to timeout error, Faraday will retry the API call up to 2 times at a 2 second interval.

Note: The POST request's body had to be manually converted to JSON for tests to pass. Doesn't appear to cause issues 

Faraday gem's [middleware docs](https://lostisland.github.io/faraday/#/middleware/index?id=middleware:~:text=The%20Awesome%20Faraday%20project%20has%20a%20complete%20list%20of%20useful%2C%20well%2Dmaintained%20Faraday%20middleware.%20Middleware%20is%20often%20provided%20by%20external%20gems%2C%20like%20the%20faraday%2Dretry%20gem.)
Faraday-retry gem's [GitHub](https://github.com/lostisland/faraday-retry)

## Issue(s):
closes #67 

## Necessary checkmarks:
- [x] All Tests are Passing
- [x] The code will run locally
- [x] Unnecessary comments removed
- [x] Test coverage 100%

## Any Outstanding Issues/Problems?
- [x] My code is wonderful, no issues here!
- [ ] Yeah, see additional words below