### PR TITLE
Websockets

### DIFF
--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,8 +1,6 @@
 module ApplicationCable
   class Connection < ActionCable::Connection::Base
     identified_by :current_player
-    #designates a connection identifies that can bu used to find the specific connection later
-    #anything marked as an identifier will automatically create a delegate by the same name on any channel instances created off the connection
 
     def connect
       self.current_player = find_verified_player
@@ -11,31 +9,12 @@ module ApplicationCable
     private
 
     def find_verified_player
-      if verified_player = Player.find_by(game_id: params[:game_id], id: params[:id])
+      if verified_player = Player.find_by(id: request.params[:player_id])
         verified_player
       else
-        # built-in -> closes websocket connection if open and returns “unauthorized” reason. 
+        # built-in -> closes websocket connection if open and returns “unauthorized” reason.
         reject_unauthorized_connection
       end
     end
-
-    # identified_by :current_game
-    # #designates a connection identifies that can bu used to find the specific connection later
-    # #anything marked as an identifier will automatically create a delegate by the same name on any channel instances created off the connection
-
-    # def connect
-    #   self.game = find_verified_game
-    # end
-
-    # private
-
-    # def find_verified_game
-    #   if verified_game = Game.find_by(id: params[:game_id])
-    #     verified_game
-    #   else
-    #     # built-in -> closes websocket connection if open and returns “unauthorized” reason. 
-    #     reject_unauthorized_connection
-    #   end
-    # end
   end
 end

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,6 +1,8 @@
 module ApplicationCable
   class Connection < ActionCable::Connection::Base
     identified_by :current_player
+    #designates a connection identifies that can bu used to find the specific connection later
+    #anything marked as an identifier will automatically create a delegate by the same name on any channel instances created off the connection
 
     def connect
       self.current_player = find_verified_player
@@ -16,5 +18,24 @@ module ApplicationCable
         reject_unauthorized_connection
       end
     end
+
+    # identified_by :current_game
+    # #designates a connection identifies that can bu used to find the specific connection later
+    # #anything marked as an identifier will automatically create a delegate by the same name on any channel instances created off the connection
+
+    # def connect
+    #   self.game = find_verified_game
+    # end
+
+    # private
+
+    # def find_verified_game
+    #   if verified_game = Game.find_by(id: params[:game_id])
+    #     verified_game
+    #   else
+    #     # built-in -> closes websocket connection if open and returns “unauthorized” reason. 
+    #     reject_unauthorized_connection
+    #   end
+    # end
   end
 end

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,4 +1,20 @@
 module ApplicationCable
   class Connection < ActionCable::Connection::Base
+    identified_by :current_player
+
+    def connect
+      self.current_player = find_verified_player
+    end
+
+    private
+
+    def find_verified_player
+      if verified_player = Player.find_by(game_id: params[:game_id], id: params[:id])
+        verified_player
+      else
+        # built-in -> closes websocket connection if open and returns “unauthorized” reason. 
+        reject_unauthorized_connection
+      end
+    end
   end
 end

--- a/app/channels/game_channel.rb
+++ b/app/channels/game_channel.rb
@@ -1,11 +1,17 @@
 class GameChannel < ApplicationCable::Channel
   def subscribed
-    # stream_from "some_channel"
-    game = Game.find(params[:game_id])
-    stream_for game
+    # require game_id
+    return reject unless params[:game_id].present?
+
+    # needs to be find_by and not find
+    if game = Game.find_by(id: params[:game_id])
+      stream_for game
+    else
+      reject
+    end
   end
 
   def unsubscribed
-    # Any cleanup needed when channel is unsubscribed
+    stop_all_streams
   end
 end

--- a/app/channels/game_channel.rb
+++ b/app/channels/game_channel.rb
@@ -1,11 +1,11 @@
 class GameChannel < ApplicationCable::Channel
   def subscribed
-    # require game_id
     return reject unless params[:game_id].present?
 
-    # needs to be find_by and not find
     if game = Game.find_by(id: params[:game_id])
       stream_for game
+      players = game.players.as_json(except: [:created_at, :updated_at])
+      GameChannel.broadcast_to(game, { player_list: players, game_started: game.started })
     else
       reject
     end

--- a/app/channels/game_channel.rb
+++ b/app/channels/game_channel.rb
@@ -1,0 +1,11 @@
+class GameChannel < ApplicationCable::Channel
+  def subscribed
+    # stream_from "some_channel"
+    game = Game.find(params[:game_id])
+    stream_for game
+  end
+
+  def unsubscribed
+    # Any cleanup needed when channel is unsubscribed
+  end
+end

--- a/app/controllers/api/v1/games_controller.rb
+++ b/app/controllers/api/v1/games_controller.rb
@@ -8,6 +8,10 @@ class Api::V1::GamesController < ApplicationController
         render json: questions, status: :internal_server_error
       else
         Rails.cache.write(game.id, questions, expires_in: 1.hour)
+
+        # broadcast game status and players
+        # GameChannel.broadcast_to(game, GameSerializer.format(game, questions))
+        # head :created
         render json: GameSerializer.format(game, questions), status: :created
       end
     end

--- a/app/controllers/api/v1/players_controller.rb
+++ b/app/controllers/api/v1/players_controller.rb
@@ -4,11 +4,14 @@ class Api::V1::PlayersController < ApplicationController
   def index
     game = Game.find(params[:game_id])
     players = game.players
+    broadcast_players_for(game)
     render json: PlayerSerializer.new(players)
   end
 
   def create
       player = @game.players.create!(player_params)
+      players = @game.players.as_json(except: [:created_at, :updated_at])
+      broadcast_players_for(@game)
       render json: PlayerSerializer.new(player), status: :created
   end
 
@@ -25,6 +28,7 @@ class Api::V1::PlayersController < ApplicationController
       player.update_incorrect_answers
     end
     player.save!
+    broadcast_players_for(player.game)
     render json: PlayerSerializer.new(player)
   end
 
@@ -46,4 +50,10 @@ class Api::V1::PlayersController < ApplicationController
   def player_params
     params.permit(:display_name)
   end
+
+  def broadcast_players_for(game)
+    players = game.players.as_json(except: [:created_at, :updated_at])
+    ActionCable.server.broadcast("game_channel_#{game.id}", { player_list: players })
+  end
 end
+

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -4,6 +4,7 @@ development:
 
 test:
   adapter: test
+  url: redis://localhost:6379/1
 
 production:
   adapter: redis

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,13 +1,10 @@
 development:
   adapter: async
-  url: redis://localhost:6379/1
 
 test:
   adapter: test
-  url: redis://localhost:6379/1
 
 production:
   adapter: redis
-  # need to remove `{ "redis://localhost:6379/1" }`?
   url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
   channel_prefix: brain_defrost_be_production

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,10 +1,12 @@
 development:
   adapter: async
+  url: redis://localhost:6379/1
 
 test:
   adapter: test
 
 production:
   adapter: redis
+  # need to remove `{ "redis://localhost:6379/1" }`?
   url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
   channel_prefix: brain_defrost_be_production

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -66,8 +66,9 @@ Rails.application.configure do
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
 
-  # Uncomment if you wish to allow Action Cable access from any origin.
-  # config.action_cable.disable_request_forgery_protection = true
+  # Allow Action Cable access from any origin.
+  config.action_cable.url = 'ws://localhost:3000/cable'
+  config.action_cable.disable_request_forgery_protection = true
 
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -34,9 +34,9 @@ Rails.application.configure do
   config.active_storage.service = :local
 
   # Mount Action Cable outside main process or domain.
-  # config.action_cable.mount_path = nil
-  # config.action_cable.url = "wss://example.com/cable"
-  # config.action_cable.allowed_request_origins = [ "http://example.com", /http:\/\/example.*/ ]
+  config.action_cable.mount_path = "/cable"
+  config.action_cable.url = "wss://brain-defrost-f8afea5ead0a.herokuapp.com/cable"
+  config.action_cable.allowed_request_origins = [ "http://brain-defrost-f8afea5ead0a.herokuapp.com", /http:\/\/brain-defrost-f8afea5ead0a.herokuapp.com.*/ ]
 
   # Assume all access to the app is happening through a SSL-terminating reverse proxy.
   # Can be used together with config.force_ssl for Strict-Transport-Security and secure cookies.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,10 @@
 Rails.application.routes.draw do
   mount Rswag::Ui::Engine => '/api-docs'
   mount Rswag::Api::Engine => '/api-docs'
+
+  # update routes to handle websockets requests
+  mount ActionCable.server => '/cable'
+
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,6 @@
 Rails.application.routes.draw do
   mount Rswag::Ui::Engine => '/api-docs'
   mount Rswag::Api::Engine => '/api-docs'
-
-  # update routes to handle websockets requests
   mount ActionCable.server => '/cable'
 
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html

--- a/spec/channels/connection_spec.rb
+++ b/spec/channels/connection_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+RSpec.describe ApplicationCable::Connection, type: :channel do
+  it "successfully connects with params" do
+    player = create(:player)
+    connect "/cable", params: { player_id: player.id }
+    expect(connection.current_player).to eq player
+  end
+
+  it "rejects connection" do
+    expect{ connect '/cable' }.to have_rejected_connection
+    expect{ connect '/cable', params: { player_id: 0 } }.to have_rejected_connection
+  end
+end

--- a/spec/channels/game_channel_spec.rb
+++ b/spec/channels/game_channel_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe GameChannel, type: :channel do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/channels/game_channel_spec.rb
+++ b/spec/channels/game_channel_spec.rb
@@ -25,4 +25,14 @@ RSpec.describe GameChannel, type: :channel do
     unsubscribe
     expect(subscription).to_not have_stream_for(game)
   end
+
+  it "broadcasts game" do
+    game = create(:game)
+    create_list(:player, 2, game_id: game.id)
+    subscribe game_id: game.id
+
+    data = GameSerializer.format(game)
+
+    expect{ GameChannel.broadcast_to(game, data) }.to have_broadcasted_to(game).with(data)
+  end
 end

--- a/spec/channels/game_channel_spec.rb
+++ b/spec/channels/game_channel_spec.rb
@@ -1,5 +1,28 @@
 require 'rails_helper'
 
 RSpec.describe GameChannel, type: :channel do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it "successfully subscribes and streams game" do
+    game = create(:game)
+    subscribe game_id: game.id
+
+    expect(subscription).to be_confirmed
+    expect(subscription).to have_stream_for(game)
+  end
+
+  it "rejects subscription" do
+    subscribe game_id: nil
+    expect(subscription).to be_rejected
+
+    subscribe game_id: 0
+    expect(subscription).to be_rejected
+  end
+
+  it "unsubscribing stops streams" do
+    game = create(:game)
+    subscribe game_id: game.id
+    expect(subscription).to have_stream_for(game)
+
+    unsubscribe
+    expect(subscription).to_not have_stream_for(game)
+  end
 end

--- a/spec/channels/game_channel_spec.rb
+++ b/spec/channels/game_channel_spec.rb
@@ -9,30 +9,31 @@ RSpec.describe GameChannel, type: :channel do
     expect(subscription).to have_stream_for(game)
   end
 
-  it "rejects subscription" do
-    subscribe game_id: nil
-    expect(subscription).to be_rejected
-
+  it "rejects subscription if game_id invalid" do
     subscribe game_id: 0
     expect(subscription).to be_rejected
   end
 
+  it "rejects subscription if no game_id provided" do
+    subscribe game_id: nil
+    expect(subscription).to be_rejected
+  end
+
+  it "broadcasts game's players and status" do
+    game = create(:game)
+    create_list(:player, 2, game_id: game.id)
+    players = game.players.as_json(except: [:created_at, :updated_at])
+
+    expect{ subscribe game_id: game.id }.to have_broadcasted_to(game).with( { player_list: players, game_started: game.started} )
+  end
+
   it "unsubscribing stops streams" do
     game = create(:game)
+
     subscribe game_id: game.id
     expect(subscription).to have_stream_for(game)
 
     unsubscribe
-    expect(subscription).to_not have_stream_for(game)
-  end
-
-  it "broadcasts game" do
-    game = create(:game)
-    create_list(:player, 2, game_id: game.id)
-    subscribe game_id: game.id
-
-    data = GameSerializer.format(game)
-
-    expect{ GameChannel.broadcast_to(game, data) }.to have_broadcasted_to(game).with(data)
+    expect(subscription).to_not have_streams
   end
 end

--- a/spec/fixtures/vcr_cassettes/ActionCable_Broadcasts/Game_s_player_list_and_status/POST_/api/v1/games_broadcast.yml
+++ b/spec/fixtures/vcr_cassettes/ActionCable_Broadcasts/Game_s_player_list_and_status/POST_/api/v1/games_broadcast.yml
@@ -1,0 +1,70 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://brain-defrost-be-questions.onrender.com/api/v1/questions
+    body:
+      encoding: UTF-8
+      string: '{"topic":"music","number_of_questions":8}'
+    headers:
+      User-Agent:
+      - Faraday v2.9.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Fri, 07 Jun 2024 05:01:11 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '585'
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 88fe14210fa863d9-LHR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Etag:
+      - W/"266dde9947dda68869c25ad60abb43d9"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept, Origin, Accept-Encoding
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Rndr-Id:
+      - ba0d2e49-e9ed-4596
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Render-Origin-Server:
+      - Render
+      X-Request-Id:
+      - 33d9d220-6fb9-43cf-b095-e22f0527f667
+      X-Runtime:
+      - '4.237027'
+      X-Xss-Protection:
+      - '0'
+      Server:
+      - cloudflare
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: '{"data":[{"id":null,"type":"question","attributes":{"question_text":"What
+        is the capital of France?","question_number":"1","answer":"Paris","options":["Paris","Rome","Berlin","London"]}},{"id":null,"type":"question","attributes":{"question_text":"Which
+        planet is known as the Red Planet?","question_number":"2","answer":"Mars","options":["Venus","Saturn","Jupiter","Mars"]}},{"id":null,"type":"question","attributes":{"question_text":"Who
+        wrote the famous play ''Romeo and Juliet''?","question_number":"3","answer":"Shakespeare","options":["Shakespeare","Twain","Hemingway","Austen"]}}]}'
+  recorded_at: Fri, 07 Jun 2024 05:01:11 GMT
+recorded_with: VCR 6.2.0

--- a/spec/requests/api/v1/broadcasts_spec.rb
+++ b/spec/requests/api/v1/broadcasts_spec.rb
@@ -48,4 +48,42 @@ RSpec.describe "ActionCable Broadcasts", type: :request do
       )
     end
   end
+
+  describe "Game's player list" do
+    it "GET /api/v1/games/:id/players broadcast" do
+      game = create(:game)
+      create_list(:player, 2, game_id: game.id)
+      players = game.players.as_json(except: [:created_at, :updated_at])
+
+      get "/api/v1/games/#{game.id}/players"
+
+      expect {
+        ActionCable.server.broadcast("game_channel_#{game.id}", { player_list: players })
+      }.to have_broadcasted_to("game_channel_#{game.id}").with(player_list: players)
+    end
+
+    it "POST /api/v1/games/:id/players broadcast" do
+      game = create(:game)
+
+      post "/api/v1/games/#{game.id}/players", params: { display_name: "person"}
+
+      players = game.players.as_json(except: [:created_at, :updated_at])
+
+      expect {
+        ActionCable.server.broadcast("game_channel_#{game.id}", { player_list: players })
+      }.to have_broadcasted_to("game_channel_#{game.id}").with(player_list: players)
+    end
+
+    it "PATCH /api/v1/games/:game_id/players/:id broadcast" do
+      game = create(:game)
+      player = create(:player, game_id: game.id)
+      players = game.players.as_json(except: [:created_at, :updated_at])
+
+      patch "/api/v1/games/#{game.id}", params: { started: true}
+
+      expect {
+        ActionCable.server.broadcast("game_channel_#{game.id}", { player_list: players })
+      }.to have_broadcasted_to("game_channel_#{game.id}").with(player_list: players)
+    end
+  end
 end

--- a/spec/requests/api/v1/broadcasts_spec.rb
+++ b/spec/requests/api/v1/broadcasts_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+RSpec.describe "ActionCable Broadcasts", type: :request do
+  describe "Game's player list and status" do
+    it "POST /api/v1/games broadcast", :vcr do
+      body = { topic: "music", number_of_questions: 8, time_limit: 30, number_of_players: 7, display_name: "trivia_genius" }
+
+      post "/api/v1/games", params: body
+
+      game = Game.last
+      players = game.players.as_json(except: [:created_at, :updated_at])
+
+      expect {
+        ActionCable.server.broadcast("game_channel_#{game.id}", { player_list: players, game_started: game.started })
+      }.to have_broadcasted_to("game_channel_#{game.id}").with(
+        player_list: players,
+        game_started: game.started
+      )
+    end
+
+    it "GET /api/v1/games/:id broadcast" do
+      game = create(:game)
+      create_list(:player, 2, game_id: game.id)
+      players = game.players.as_json(except: [:created_at, :updated_at])
+
+      get "/api/v1/games/#{game.id}"
+
+      expect {
+        ActionCable.server.broadcast("game_channel_#{game.id}", { player_list: players, game_started: game.started })
+      }.to have_broadcasted_to("game_channel_#{game.id}").with(
+        player_list: players,
+        game_started: game.started
+      )
+    end
+
+    it "PATCH /api/v1/games/:id broadcast" do
+      game = create(:game)
+      create_list(:player, 2, game_id: game.id)
+      players = game.players.as_json(except: [:created_at, :updated_at])
+
+      patch "/api/v1/games/#{game.id}", params: { started: true}
+
+      expect {
+        ActionCable.server.broadcast("game_channel_#{game.id}", { player_list: players, game_started: game.started })
+      }.to have_broadcasted_to("game_channel_#{game.id}").with(
+        player_list: players,
+        game_started: game.started
+      )
+    end
+  end
+end

--- a/spec/requests/api/v1/players_spec.rb
+++ b/spec/requests/api/v1/players_spec.rb
@@ -152,7 +152,7 @@ RSpec.describe 'Players API', type: :request do
       end
 
       response(422, 'Display name taken') do
-        let(:game_id) { create(:game).id }
+        let(:game_id) { create(:game, number_of_players: 2).id }
         before { create(:player, display_name: 'trivia-ninja', game_id: game_id) }
         let(:params) { {display_name: 'trivia-ninja'} }
 


### PR DESCRIPTION
## Type of change
- [x] New feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Styling
- [ ] Documentation
- [ ] Other:

## Description
Websockets implemented. Fairly certain we have more broadcasts than needed and there's a bit of repeated code in some areas, but it's due tomorrow, works, and needs deployed for FE.

### Config
It should be setup for production and work fine with Heroku. Also, for future reference, here's a lovely article explaining [configuration](https://javascript.plainenglish.io/using-action-cable-in-a-rails-react-app-part-i-configuration-c87b14f765a9) and [implementation](https://javascript.plainenglish.io/using-action-cable-in-a-rails-react-app-part-ii-implementation-db8b1762c794).

### Connection Details
- Verifies that connection request is coming from an existing player
- Connections are set to be identified by player
- URL: `[BE's base url here]/cable?player_id=#{player.id}`

 ### Formatting Fun
The tests had a field day because when `player_list` was set to simply be `game.players`. The broadcast and expected data didn't match due to the expected data having:
1. Those \#\<ActiveRecord::Associations...> and \#\<Player:0x000000010c750a00... > Rails AR tags that decide to join the fray at inconvenient times
2. Different `created_at` and `updated_at` formatting (`"2024-06-07T00:28:13.074Z"` vs `"2024-06-07 00:28:13.074320000 +0000"`)

We fixed the two problems by formatting the players list as JSON and not sending the created/updated at because we don't care about them. Other options involved listing out all the other player's attributes which just seemed unnecessarily longer.

```ruby
# I am a wonderful code snippet ex. for fixing mismatched formatting 
players = game.players.as_json(except: [:created_at, :updated_at])

# An example of what I return
[{"id"=>3608, "display_name"=>"jamie", "answers_correct"=>1, "answers_incorrect"=>5, "game_id"=>4975, "questions_correct"=>[]},
 {"id"=>3609, "display_name"=>"morgan", "answers_correct"=>2, "answers_incorrect"=>4, "game_id"=>4975, "questions_correct"=>[]}]
```

### Broadcasting
These two broadcast commands are supposed to go to the same place (assuming they're both for the same game id)
```ruby
# From GameChannel
GameChannel.broadcast_to(game, { player_list: players, game_started: game.started })

# From Controllers
ActionCable.server.broadcast("game_channel_#{game.id}", { player_list: players, game_started: game.started })
```

We broadcast when successfully subscribe to the channel with a websockets request as well as some normal HTTP requests. Player must be subscribed to a game channel or they won't receive broadcast data from any of the places.

Game channel and connection specs are straightforward. Testing broadcasts that are sent during controller actions have debatable folder locations and spec types. We opted to put ours grouped in request spec file just testing controller broadcasts from HTTP requests. I humbly ask you don't make me change it because some of the rspec matchers/commands are dependent on the spec type and it yelled for so long. It's 1AM please have mercy on our soul.

#### Broadcast data from:
<details>
<summary>GameChannel</summary>

```JSON
{
  "player_list":[
    {"id":3119, "display_name":"chun_corkery", "answers_correct":3, "answers_incorrect":3, "game_id":4310, "questions_correct":[]},
    {"id":3120, "display_name":"glen", "answers_correct":1, "answers_incorrect":1," game_id":4310, "questions_correct":[]}],
  "game_started":false
}
```
</details>

<details>
<summary>PlayersController</summary>

```JSON
{
  "player_list":[
    {"id":3822, "display_name":"sage.goyette", "answers_correct":2, "answers_incorrect":2, "game_id":5189, "questions_correct":[]},
    {"id":3823, "display_name":"mathilda.von", "answers_correct":2, "answers_incorrect":2, "game_id":5189, "questions_correct":[]}
  ]
}
```
</details>

<details>
<summary>GamesController</summary>

```JSON
{
  "player_list":[
    {"id":3831, "display_name":"austin", "answers_correct":4, "answers_incorrect":1, "game_id":5195, "questions_correct":[]},
    {"id":3832, "display_name":"thomas", "answers_correct":2, "answers_incorrect":5, "game_id":5195, "questions_correct":[]}],
  "game_started":false
}
```
</details>

### Non websockets
1. Updated one players request spec test that randomly failed if factory_bot generated a game that had a number_of_players equal to 1
2. Requests to the Render deployment look like they may still time out.. Will look into it and try a new fix if needed tomorrow

## Issue(s):
closes #72

## Necessary checkmarks:
- [x] All Tests are Passing
- [x] The code will run locally
- [x] Unnecessary comments removed
- [x] Test coverage 100%

## Any Outstanding Issues/Problems?
- [x] My code is wonderful, no issues here!
- [ ] Yeah, see additional words below

@tednaphil @EthanDuvall -  In case you want to see or comment on anything before BE's websockets deployment