### PR TITLE
fix questions service and patch game

### DIFF
--- a/app/controllers/api/v1/games_controller.rb
+++ b/app/controllers/api/v1/games_controller.rb
@@ -27,8 +27,8 @@ class Api::V1::GamesController < ApplicationController
     game.update!(game_params)
     questions = Rails.cache.read(game.id)
     questions ||= []
-    broadcast_players_and_status_for(game)
     render json: GameSerializer.format(game, questions)
+    broadcast_players_and_status_for(game)
   end
 
   private 

--- a/app/services/question_service.rb
+++ b/app/services/question_service.rb
@@ -1,5 +1,3 @@
-require 'faraday/retry'
-
 class QuestionService
   def self.create_questions_for(game)
     post_url("/api/v1/questions", game)
@@ -7,13 +5,11 @@ class QuestionService
   end
 
   def self.post_url(url, params)
-    response = conn.post(url, JSON.generate(params))
+    response = conn.post(url, params)
     @parsed_json = JSON.parse(response.body, symbolize_names: true)
   end
 
   def self.conn
-    Faraday.new(url: "https://brain-defrost-be-questions.onrender.com") do |faraday|
-      faraday.request :retry, max: 2, interval: 2, exceptions: [Faraday::TimeoutError]
-    end
+    Faraday.new(url: "https://brain-defrost-be-questions.onrender.com")
   end
 end

--- a/spec/requests/api/v1/broadcasts_spec.rb
+++ b/spec/requests/api/v1/broadcasts_spec.rb
@@ -38,7 +38,8 @@ RSpec.describe "ActionCable Broadcasts", type: :request do
       create_list(:player, 2, game_id: game.id)
       players = game.players.as_json(except: [:created_at, :updated_at])
 
-      patch "/api/v1/games/#{game.id}", params: { started: true}
+      patch "/api/v1/games/#{game.id}", params: { started: true }
+      game.update!(started: true)
 
       expect {
         ActionCable.server.broadcast("game_channel_#{game.id}", { player_list: players, game_started: game.started })
@@ -79,7 +80,7 @@ RSpec.describe "ActionCable Broadcasts", type: :request do
       player = create(:player, game_id: game.id)
       players = game.players.as_json(except: [:created_at, :updated_at])
 
-      patch "/api/v1/games/#{game.id}", params: { started: true}
+      patch "/api/v1/games/#{game.id}", params: { question: 1, correct: true }
 
       expect {
         ActionCable.server.broadcast("game_channel_#{game.id}", { player_list: players })


### PR DESCRIPTION
## Type of change
- [ ] New feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Styling
- [ ] Documentation
- [ ] Other:

## Description

A new game had the same 3 questions every time. Question service updated to take away retry patch on timeout and params sent out as they originally were. 
Switched to rendering json and then broadcasting for game patch request to hopefully try and fix FE's issue w/someone needing to reload for the game status to update.

## Necessary checkmarks:
- [x] All Tests are Passing
- [x] The code will run locally
- [x] Unnecessary comments removed
- [x] Test coverage 100%

## Any Outstanding Issues/Problems?
- [x] My code is wonderful, no issues here!
- [ ] Yeah, see additional words below