### PR TITLE
start_game for GameChannel

### DIFF
--- a/app/channels/game_channel.rb
+++ b/app/channels/game_channel.rb
@@ -14,4 +14,9 @@ class GameChannel < ApplicationCable::Channel
   def unsubscribed
     stop_all_streams
   end
+
+  def start_game
+    game = Game.find(params[:game_id])
+    GameChannel.broadcast_to(game, { game_started: game.started }) if game.started?
+  end
 end


### PR DESCRIPTION
## Type of change
- [ ] New feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Styling
- [ ] Documentation
- [ ] Other:

## Description

Added a start_game method to the GameChannel to try and fix the issue of not broadcasting when a game is updated properly.

Not currently tested. Just going for it bc time.